### PR TITLE
Feature/sapi 955 add dropdown to select service

### DIFF
--- a/dev-helpers/index.html
+++ b/dev-helpers/index.html
@@ -42,7 +42,10 @@
       window["SwaggerUIStandalonePreset"] = window["swagger-ui-standalone-preset"]
       // Build a system
       const ui = SwaggerUIBundle({
-        url: "https://petstore.swagger.io/v2/swagger.json",
+        urls: [
+                { name: "Stalker Staging", url: "https://staging-centr.loupactive.com/swagger/v{version}/swagger.json", versions: ["2.1","2.4", "2.5"] },
+                { name: "Library service", url: "https://localhost:7072/api/v{version}/w/library/swagger", versions: ["3.0", "4.0"]}
+              ],
         dom_id: '#swagger-ui',
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/src/plugins/topbar/topbar.jsx
+++ b/src/plugins/topbar/topbar.jsx
@@ -17,12 +17,6 @@ export default class Topbar extends React.Component {
     this.state = { url: props.specSelectors.url(), selectedIndex: 0, selectedVersionIndex: 0, availableVersions: []}
   }
 
-  // static getDerivedStateFromProps(props, state) {
-  //   return {
-  //     urls: props.getConfigs() ? props.getConfigs().url : null
-  //   }
-  // }
-
   componentWillReceiveProps(nextProps) {
     this.setState({ url: nextProps.specSelectors.url() })
   }


### PR DESCRIPTION
Added in a secondary dropdown to select version based on the versions provided.

The versions are configured at the index.html level where SwaggerUIBundle is instantiated.

A versions array is to be provided for each URL configured to be displayed.

The URL for each API should have v{version} for this to work correctly.